### PR TITLE
building libde265 for ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,4 @@ script:
 before_deploy:
 - cd ..
 
-deploy:
-  skip_cleanup: true
-  provider: releases
-  api_key:
-    secure: ZobwRwAywhnRLIJoRNNud5vVHbXLXw/tj3okxa2u4jRqzw4/IDtnMluoOKGkBx/eBg80IoC6Wic7vxZyryD3UWhty9cEn50I8UsnT75flrNrOGQStHl+FrDpWn+OMk3rjNunkXzlq+bn4U+nA4UQSbtNrZ4ONKNMipzrDqJ6KKqya2ONIi3w94lqm0E2P0mboYqGd5LXSTrZ2fHpyakAJaE2RMBhO7vQplgo2jG23P4kT0ivOT7PS4gPf2fvGip6S+VmNiXGC/Pkk6RwecKtIp9KC5o6QwcDnmTkTwV8ExEMLvTVlzaNNCHI3RG1GD78ZQVKD6iI5IEe/JfsUiELPGLUBsmoladWvD6SuMOZijPWkHv+D3KV8WQLTQMczk5oZ8NQhBto05HrMXPcQ55sj9KRQWJ7Yd29y1L/Ghqj9iDXIJXK9xamEgBTsE+AI2mqh+cmE1+H1rwK1K0TcGAixcQANA6QRAtO74a1o20QmwxwQByLY4EW+UnafebWZKBiYFSTmRLgokQHOD5AnsRkKocKEcbEccpnifhIVuL5xveW9Hy1aueVYg0jiyG9FzOuNFRXRmTO2eBEjtZsamoA42U6i1vt0FqvRBISUwBPfJ76NKP1fy+rjltS5GHIuLFNaZlk71cmmsIJVtBJTIqzXmBXiNfbhjeAGLuybeejohY=
-  file: $DEPLOY_FILE
-  on:
-    repo: ChristianFeldmann/libde265
-    tags: true
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,5 +66,14 @@ else()
 endif()
 
 add_subdirectory (libde265)
-add_subdirectory (dec265)
-add_subdirectory (enc265)
+
+
+option(ONLY_LIB "Only build the libde265" OFF)
+if(${ONLY_LIB})
+  message("Only building libde265")
+else()
+  message("Building libde265 and enc/dec265")  
+  add_subdirectory (dec265)
+  add_subdirectory (enc265)
+endif()
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,10 +24,3 @@ build_script:
 artifacts:
   - path: build/libde265/Release/libde265.dll
 
-deploy:
-  provider: GitHub
-  auth_token:
-    secure: boWJ9aVfVBpOkBGzWF5yS5/Os3eDUjFfziOY04+LNA+7v+PnMFBtHeMJe2PjK4gm
-  artifact: build/libde265/Release/libde265.dll
-  on:
-    appveyor_repo_tag: true        # deploy on tag push only

--- a/libde265/CMakeLists.txt
+++ b/libde265/CMakeLists.txt
@@ -89,6 +89,6 @@ if(UNIX)
   INSTALL(TARGETS
     #libaries
     ${LIBDE265_LIBRARY_NAME}
-    LIBRARY DESTINATION "/usr/lib/x86_64-linux-gnu/"
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   )
 endif()

--- a/libde265/CMakeLists.txt
+++ b/libde265/CMakeLists.txt
@@ -83,3 +83,12 @@ target_link_libraries(${LIBDE265_LIBRARY_NAME} ${CMAKE_THREAD_LIBS_INIT})
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
   SET_TARGET_PROPERTIES(${LIBDE265_LIBRARY_NAME} PROPERTIES COMPILE_FLAGS "-fPIC")
 endif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+
+if(UNIX)
+  # could not find out how to determin library install path platform independent. this is for ubuntu (16.04)
+  INSTALL(TARGETS
+    #libaries
+    ${LIBDE265_LIBRARY_NAME}
+    LIBRARY DESTINATION "/usr/lib/x86_64-linux-gnu/"
+  )
+endif()


### PR DESCRIPTION
added option to cmake file to only build the lib
added install target for the lib, matching ubuntu 16.04